### PR TITLE
Add example of to_a

### DIFF
--- a/examples/to_a.rb
+++ b/examples/to_a.rb
@@ -1,0 +1,23 @@
+require 'rx'
+
+source = RX::Observable.timer(0, 0.1)
+    .take(5)
+    .to_a
+
+subscription = source.subscribe(
+    lambda {|x|
+        puts 'Next: ' + x.to_s
+    },
+    lambda {|err|
+        puts 'Error: ' + err.to_s
+    },
+    lambda {
+        puts 'Completed'
+    })
+
+# => Next: [0, 1, 2, 3, 4]
+# => Completed
+
+while Thread.list.size > 1
+  (Thread.list - [Thread.current]).each &:join
+end

--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -518,7 +518,16 @@ module RX
     # Creates an array from an observable sequence.
     # @return [RX::Observable] An array created from an observable sequence.
     def to_a
-      reduce([]) {|acc, x| acc.push x }
+      AnonymousObservable.new do |observer|
+        arr = []
+        self.subscribe(
+          arr.method(:push),
+          observer.method(:on_error),
+          lambda {
+            observer.on_next arr
+            observer.on_completed
+          })
+      end
     end
 
     class HashConfiguration


### PR DESCRIPTION
Avoid fiber error for examples/to_a.rb

I don't know why the fiber error is caused.