### PR TITLE
Remove redundant rake task declaration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require "bundler/gem_tasks"
 require 'rake/clean'
 require 'rake/testtask'
 
-Bundler::GemHelper.install_tasks
-
 task default: :test
 
 Rake::TestTask.new do |task|


### PR DESCRIPTION
 The line `Bundler::GemHelper.install_tasks` in the Rakefile is actually redundant because the method is called in the  [gem_tasks](https://github.com/bundler/bundler/blob/master/lib/bundler/gem_tasks.rb#L2) which is required on the top of the Rakefile. It turns out that install tasks are defined twice. So, when you call `$rake install`, the install task run twice.

Before
```
$ rake install
Rx.rb 0.0.1 built to pkg/Rx.rb-0.0.1.gem.
Rx.rb 0.0.1 built to pkg/Rx.rb-0.0.1.gem.
Rx.rb (0.0.1) installed.
Rx.rb (0.0.1) installed.
```

After
```
$ rake install
Rx.rb 0.0.1 built to pkg/Rx.rb-0.0.1.gem.
Rx.rb (0.0.1) installed.
```