### PR TITLE
Add simplecov

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,6 @@ require 'rake/testtask'
 task default: :test
 
 Rake::TestTask.new do |task|
+  task.libs.unshift(File.expand_path('../test', __FILE__))
   task.test_files = FileList['test/**/test*.rb']
 end

--- a/Rx.rb.gemspec
+++ b/Rx.rb.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
+  gem.add_development_dependency 'simplecov'
 end

--- a/test/rx/concurrency/test_async_lock.rb
+++ b/test/rx/concurrency/test_async_lock.rb
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
-
+require 'test_helper'
 require 'thread'
 
 class TestAsyncLock < Minitest::Test

--- a/test/rx/concurrency/test_current_thread_scheduler.rb
+++ b/test/rx/concurrency/test_current_thread_scheduler.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 module RX
   # Extend to include ensure trampoline

--- a/test/rx/concurrency/test_default_scheduler.rb
+++ b/test/rx/concurrency/test_default_scheduler.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestDefaultScheduler < Minitest::Test
 

--- a/test/rx/concurrency/test_immediate_scheduler.rb
+++ b/test/rx/concurrency/test_immediate_scheduler.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestImmediateScheduler < Minitest::Test
   def test_now

--- a/test/rx/concurrency/test_scheduled_item.rb
+++ b/test/rx/concurrency/test_scheduled_item.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestScheduledItem < Minitest::Test
 

--- a/test/rx/concurrency/test_scheduler.rb
+++ b/test/rx/concurrency/test_scheduler.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class MyScheduler
   include RX::Scheduler

--- a/test/rx/concurrency/test_virtual_time_scheduler.rb
+++ b/test/rx/concurrency/test_virtual_time_scheduler.rb
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class VirtualSchedulerTestScheduler < RX::VirtualTimeScheduler
   def initialize(clock = '')

--- a/test/rx/core/test_notification.rb
+++ b/test/rx/core/test_notification.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestNotification < Minitest::Test
   include RX::ReactiveTest

--- a/test/rx/core/test_observable_creation.rb
+++ b/test/rx/core/test_observable_creation.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestObservableCreation < Minitest::Test
   include RX::ReactiveTest

--- a/test/rx/core/test_observer.rb
+++ b/test/rx/core/test_observer.rb
@@ -2,8 +2,7 @@
 
 require 'monitor'
 require 'thread'
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class MyObserver
   include RX::Observer

--- a/test/rx/internal/test_priority_queue.rb
+++ b/test/rx/internal/test_priority_queue.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestPriorityQueue < Minitest::Test
 

--- a/test/rx/subscriptions/test_composite_subscription.rb
+++ b/test/rx/subscriptions/test_composite_subscription.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestCompositeSubscription < Minitest::Test
 

--- a/test/rx/subscriptions/test_serial_subscription.rb
+++ b/test/rx/subscriptions/test_serial_subscription.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestSerialSubscription < Minitest::Test
 

--- a/test/rx/subscriptions/test_singleassignment_subscription.rb
+++ b/test/rx/subscriptions/test_singleassignment_subscription.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestSingleAssignmentSubscription < Minitest::Test
 

--- a/test/rx/subscriptions/test_subscription.rb
+++ b/test/rx/subscriptions/test_subscription.rb
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-require 'minitest/autorun'
-require 'rx'
+require 'test_helper'
 
 class TestSubscription < Minitest::Test
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,9 @@
+require 'minitest/autorun'
+require 'simplecov'
+
+SimpleCov.start do
+  coverage_dir '.coverage'
+  add_filter 'test/'
+end
+
+require 'rx'


### PR DESCRIPTION
This adds SimpleCov to track test coverage since this was mentioned as an issue impeding considering Rx.rb "production ready" in #60.