### PR TITLE
Fix autorun before starting coverage

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
-require 'minitest/autorun'
 require 'simplecov'
 
 SimpleCov.start do
@@ -6,4 +5,5 @@ SimpleCov.start do
   add_filter 'test/'
 end
 
+require 'minitest/autorun'
 require 'rx'


### PR DESCRIPTION
Requiring minitest/autorun before starting SimpleCov short circuits coverage calculations.