### PR TITLE
Prevent generating coverage report on Travis

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
-require 'simplecov'
+if ENV['COVERAGE']
+  require 'simplecov'
 
-SimpleCov.start do
-  coverage_dir '.coverage'
-  add_filter 'test/'
+  SimpleCov.start do
+    coverage_dir '.coverage'
+    add_filter 'test/'
+  end
 end
 
 require 'minitest/autorun'


### PR DESCRIPTION
This commit limits to coverage generation to if `ENV['COVERAGE']` exists.  This _should_ prevent Travis from trying to include/run SimpleCov, fixing rbx build failures.